### PR TITLE
Add async clock generator module

### DIFF
--- a/async_clock_gen.sv
+++ b/async_clock_gen.sv
@@ -1,0 +1,39 @@
+module async_clock_gen #(
+    parameter int DIV_A = 3,
+    parameter int DIV_B = 5
+) (
+    input  logic clk_in,
+    input  logic rst_n,
+    output logic clk_a,
+    output logic clk_b
+);
+    localparam int WIDTH_A = $clog2(DIV_A);
+    localparam int WIDTH_B = $clog2(DIV_B);
+
+    logic [WIDTH_A-1:0] cnt_a;
+    logic [WIDTH_B-1:0] cnt_b;
+
+    always_ff @(posedge clk_in or negedge rst_n) begin
+        if (!rst_n) begin
+            cnt_a <= '0;
+            clk_a <= 1'b0;
+        end else if (cnt_a == DIV_A - 1) begin
+            cnt_a <= '0;
+            clk_a <= ~clk_a;
+        end else begin
+            cnt_a <= cnt_a + 1'b1;
+        end
+    end
+
+    always_ff @(posedge clk_in or negedge rst_n) begin
+        if (!rst_n) begin
+            cnt_b <= '0;
+            clk_b <= 1'b0;
+        end else if (cnt_b == DIV_B - 1) begin
+            cnt_b <= '0;
+            clk_b <= ~clk_b;
+        end else begin
+            cnt_b <= cnt_b + 1'b1;
+        end
+    end
+endmodule

--- a/top.sv
+++ b/top.sv
@@ -1,3 +1,16 @@
-module top();
-
+module top (
+    input  logic clk,
+    input  logic rst_n,
+    output logic clk_a,
+    output logic clk_b
+);
+    async_clock_gen #(
+        .DIV_A(3),
+        .DIV_B(5)
+    ) u_gen (
+        .clk_in (clk),
+        .rst_n  (rst_n),
+        .clk_a  (clk_a),
+        .clk_b  (clk_b)
+    );
 endmodule


### PR DESCRIPTION
## Summary
- add `async_clock_gen` module that produces two divided clocks from a single input
- update `top` module to instantiate the async clock generator

## Testing
- `verilator --lint-only top.sv async_clock_gen.sv` *(fails: command not found)*
- `apt-get update >/tmp/apt.log && tail -n 20 /tmp/apt.log` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ac90179fb883218ea2b4706ae05b74